### PR TITLE
Add placeholder pipeline UI with tabs

### DIFF
--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -1,0 +1,62 @@
+function selectTab(id) {
+  document.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
+  document.querySelectorAll('.tab-content').forEach(tab => tab.classList.remove('active'));
+  document.querySelector(`.tab-button[data-tab="${id}"]`).classList.add('active');
+  document.getElementById(id).classList.add('active');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.tab-button').forEach(btn => {
+    btn.addEventListener('click', () => selectTab(btn.dataset.tab));
+  });
+
+  document.getElementById('start-btn').addEventListener('click', async () => {
+    const input = document.getElementById('research-input').value;
+    const tabs = document.getElementById('tabs');
+    tabs.style.display = 'block';
+
+    // Plan
+    selectTab('plan');
+    const planRes = await fetch('/api/plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: input })
+    });
+    const planData = await planRes.json();
+    document.getElementById('plan-output').textContent = planData.experimentSpec;
+
+    // Codegen
+    selectTab('codegen');
+    const codegenRes = await fetch('/api/codegen', { method: 'POST' });
+    const codegenData = await codegenRes.json();
+    const fileTabs = document.getElementById('file-tabs');
+    const fileContent = document.getElementById('file-content');
+    fileTabs.innerHTML = '';
+    let first = true;
+    Object.entries(codegenData.files || {}).forEach(([name, content]) => {
+      const b = document.createElement('button');
+      b.textContent = name;
+      b.addEventListener('click', () => {
+        fileContent.textContent = content;
+      });
+      fileTabs.appendChild(b);
+      if (first) {
+        fileContent.textContent = content;
+        first = false;
+      }
+    });
+
+    // Execute
+    selectTab('execute');
+    const executeRes = await fetch('/api/execute', { method: 'POST' });
+    const executeData = await executeRes.json();
+    document.getElementById('execute-output').textContent = JSON.stringify(executeData, null, 2);
+
+    // Report
+    selectTab('report');
+    const reportRes = await fetch('/api/report', { method: 'POST' });
+    const reportData = await reportRes.json();
+    document.getElementById('report-output').textContent = reportData.summary;
+  });
+});
+

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,9 +3,41 @@
 <head>
   <meta charset="UTF-8" />
   <title>Cognition Hackathon Frontend</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    #tabs { margin-top: 20px; }
+    .tab-buttons { display: flex; gap: 4px; margin-bottom: 10px; }
+    .tab-buttons button { padding: 5px 10px; }
+    .tab-content { display: none; border: 1px solid #ccc; padding: 10px; }
+    .tab-content.active { display: block; }
+    .tab-buttons button.active { background: #007bff; color: #fff; }
+    #file-tabs button { margin-right: 4px; }
+  </style>
 </head>
 <body>
-  <h1>Frontend is running</h1>
-  <p>Edit this page in <code>frontend/public/index.html</code>.</p>
+  <h1>Cognition Research UI</h1>
+  <div id="chat">
+    <input id="research-input" type="text" placeholder="Describe your experiment" style="width:70%" />
+    <button id="start-btn">Start</button>
+  </div>
+
+  <div id="tabs" style="display:none;">
+    <div class="tab-buttons">
+      <button class="tab-button active" data-tab="plan">Plan</button>
+      <button class="tab-button" data-tab="codegen">Codegen</button>
+      <button class="tab-button" data-tab="execute">Execute</button>
+      <button class="tab-button" data-tab="report">Report</button>
+    </div>
+    <div id="plan" class="tab-content active"><pre id="plan-output"></pre></div>
+    <div id="codegen" class="tab-content">
+      <div id="file-tabs"></div>
+      <pre id="file-content"></pre>
+    </div>
+    <div id="execute" class="tab-content"><pre id="execute-output"></pre></div>
+    <div id="report" class="tab-content"><pre id="report-output"></pre></div>
+  </div>
+
+  <script src="app.js"></script>
 </body>
 </html>
+

--- a/server/index.js
+++ b/server/index.js
@@ -3,9 +3,41 @@ const cors = require('cors');
 
 const app = express();
 app.use(cors());
+app.use(express.json());
 
 app.get('/api/hello', (req, res) => {
   res.json({ message: 'Hello from server!' });
+});
+
+app.post('/api/plan', (req, res) => {
+  const { prompt } = req.body || {};
+  res.json({
+    prompt,
+    experimentSpec: '{"model": "Placeholder spec"}'
+  });
+});
+
+app.post('/api/codegen', (req, res) => {
+  res.json({
+    files: {
+      'train.py': '# train model\n',
+      'eval.py': '# evaluate model\n',
+      'model.py': '# model definition\n'
+    }
+  });
+});
+
+app.post('/api/execute', (req, res) => {
+  res.json({
+    metrics: { accuracy: 0.0 },
+    plots: []
+  });
+});
+
+app.post('/api/report', (req, res) => {
+  res.json({
+    summary: 'Placeholder summary.'
+  });
 });
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add placeholder API endpoints for plan, codegen, execute, and report
- build frontend with chat input and tabbed views for each pipeline stage
- implement client logic to sequentially populate each tab from backend

## Testing
- `cd server && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f842ecdc832eb40f9bb058550674