### PR TITLE
feat: support split Railway deployments

### DIFF
--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -18,3 +18,7 @@ Use the default Node.js environment on Railway with the start command:
 ```
 npm start
 ```
+
+Set the `API_BASE_URL` environment variable to the URL of your FastAPI
+backend (e.g. `https://your-server.up.railway.app`) so the frontend can
+communicate with it.

--- a/src/frontend/public/app.js
+++ b/src/frontend/public/app.js
@@ -15,9 +15,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const tabs = document.getElementById('tabs');
     tabs.style.display = 'block';
 
+    const baseUrl = window.API_BASE_URL || '';
+
     // Plan
     selectTab('plan');
-    const planRes = await fetch('/api/plan', {
+    const planRes = await fetch(`${baseUrl}/api/plan`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: input })
@@ -27,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Codegen
     selectTab('codegen');
-    const codegenRes = await fetch('/api/codegen', { method: 'POST' });
+    const codegenRes = await fetch(`${baseUrl}/api/codegen`, { method: 'POST' });
     const codegenData = await codegenRes.json();
     const fileTabs = document.getElementById('file-tabs');
     const fileContent = document.getElementById('file-content');
@@ -48,13 +50,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Execute
     selectTab('execute');
-    const executeRes = await fetch('/api/execute', { method: 'POST' });
+    const executeRes = await fetch(`${baseUrl}/api/execute`, { method: 'POST' });
     const executeData = await executeRes.json();
     document.getElementById('execute-output').textContent = JSON.stringify(executeData, null, 2);
 
     // Report
     selectTab('report');
-    const reportRes = await fetch('/api/report', { method: 'POST' });
+    const reportRes = await fetch(`${baseUrl}/api/report`, { method: 'POST' });
     const reportData = await reportRes.json();
     document.getElementById('report-output').textContent = reportData.summary;
   });

--- a/src/frontend/public/index.html
+++ b/src/frontend/public/index.html
@@ -37,6 +37,7 @@
     <div id="report" class="tab-content"><pre id="report-output"></pre></div>
   </div>
 
+  <script src="/config.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/src/frontend/server.js
+++ b/src/frontend/server.js
@@ -2,6 +2,16 @@ const express = require('express');
 const path = require('path');
 
 const app = express();
+
+// Serve a small JS file that exposes the backend API URL so the
+// frontend can talk to the separately hosted FastAPI server.
+app.get('/config.js', (_req, res) => {
+  const apiBase = process.env.API_BASE_URL || '';
+  res.type('application/javascript');
+  res.send(`window.API_BASE_URL = '${apiBase}';`);
+});
+
+// Static assets for the app live in /public.
 const publicPath = path.join(__dirname, 'public');
 app.use(express.static(publicPath));
 

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -10,6 +10,8 @@ poetry run uvicorn server.main:app --reload
 ```
 
 The server listens on the `PORT` environment variable (defaults to `3000`).
+It has permissive CORS settings so that a frontend deployed on another
+service (or domain) can communicate with it.
 
 ## Deployment
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,7 +1,18 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 import os
 
 app = FastAPI()
+
+# Allow cross-origin requests from any domain so the frontend can
+# be hosted separately (e.g. on a different Railway service).
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/api/hello")


### PR DESCRIPTION
## Summary
- Serve a dynamic config file in the Node frontend to expose an `API_BASE_URL`
- Add CORS to FastAPI backend so a separately hosted frontend can access it
- Document new deployment variables for frontend and server

## Testing
- `npm test`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899078f62d8832e81fa6ed6f2f7cadd